### PR TITLE
update playwright to 1.57.0

### DIFF
--- a/deps.edn
+++ b/deps.edn
@@ -2,7 +2,7 @@
  {org.clojure/clojure {:mvn/version "1.11.1"}
   camel-snake-kebab/camel-snake-kebab {:mvn/version "0.4.3"}
   garden/garden {:mvn/version "1.3.10"}
-  com.microsoft.playwright/playwright {:mvn/version "1.50.0"}
+  com.microsoft.playwright/playwright {:mvn/version "1.57.0"}
   metosin/jsonista {:mvn/version "0.3.7"}}
 
  :aliases {:build {:deps {io.github.seancorfield/build-clj


### PR DESCRIPTION
The older version of playwright didn't render my page properly, but the newest one (`1.57.0`) works like a charm!

FYI, if anyone else needs this (or if there are future versions pending update here) you don't need to wait until its merged, you can use `:override-deps`:

```clojure
:extra-deps {io.github.pfeodrippe/wally {:mvn/version "0.0.4"}}
:override-deps {com.microsoft.playwright/playwright {:mvn/version "1.57.0"}}

```