### PR TITLE
fix: use Consumer reify for .onClose to support Playwright 1.57

### DIFF
--- a/src/wally/main.clj
+++ b/src/wally/main.clj
@@ -22,7 +22,7 @@
    (garden.selectors CSSSelector)
    (java.io File)
    (java.nio.file Paths)
-   (java.util.function Predicate)
+   (java.util.function Consumer Predicate)
    (com.microsoft.playwright.assertions PlaywrightAssertions)))
 
 (def ^:private object-mapper
@@ -82,7 +82,8 @@
        (doto page
          (.setDefaultTimeout 10000)
          (#(swap! page->playwright assoc % pw))
-         (.onClose #(swap! page->playwright dissoc %)))))))
+         (.onClose (reify Consumer
+                     (accept [_ p] (swap! page->playwright dissoc p)))))))))
 
 (defonce ^:dynamic ^Page *page*
   (make-page))


### PR DESCRIPTION
## Problem

Playwright 1.57 changed `Page.onClose` to accept `Consumer<Page>` instead of a `Runnable`. Passing a Clojure anonymous function directly no longer works — the JVM throws:

```
ClassCastException: Cannot cast wally.main$make_page$fn to java.util.function.Consumer
```

This makes `make-page` (and therefore `with-page-open`) broken with the current Playwright 1.57 dependency.

## Fix

Use `reify Consumer` to wrap the page-close handler:

```clojure
;; before
(.onClose #(swap! page->playwright dissoc %))

;; after
(.onClose (reify Consumer
            (accept [_ p] (swap! page->playwright dissoc p))))
```

Also imports `java.util.function.Consumer` in the `ns` form.

## Test plan

- [ ] `make-page` and `with-page-open` work without ClassCastException
- [ ] Existing tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)