### PR TITLE
Bump Clojure to 1.12

### DIFF
--- a/deps.edn
+++ b/deps.edn
@@ -1,5 +1,5 @@
 {:deps
- {org.clojure/clojure {:mvn/version "1.11.1"}
+ {org.clojure/clojure {:mvn/version "1.12.5"}
   camel-snake-kebab/camel-snake-kebab {:mvn/version "0.4.3"}
   garden/garden {:mvn/version "1.3.10"}
   com.microsoft.playwright/playwright {:mvn/version "1.57.0"}


### PR DESCRIPTION
Addresses `ClassCastException` regression detailed in https://github.com/pfeodrippe/wally/pull/16. (1.12, which added functional interface interop ([CLJ-2799](https://clojure.atlassian.net/browse/CLJ-2799)), is required for the current code to compile).